### PR TITLE
Add support to download files as a zip

### DIFF
--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/FileApiClient.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/FileApiClient.java
@@ -9,6 +9,7 @@ import com.smartling.api.sdk.file.parameters.FileLastModifiedParameterBuilder;
 import com.smartling.api.sdk.file.parameters.FileListSearchParameterBuilder;
 import com.smartling.api.sdk.file.parameters.FileUploadParameterBuilder;
 import com.smartling.api.sdk.file.parameters.GetFileParameterBuilder;
+import com.smartling.api.sdk.file.parameters.GetFilesArchiveParameterBuilder;
 import com.smartling.api.sdk.file.parameters.GetOriginalFileParameterBuilder;
 import com.smartling.api.sdk.file.response.EmptyResponse;
 import com.smartling.api.sdk.file.response.FileImportSmartlingData;
@@ -33,6 +34,8 @@ public interface FileApiClient
     FileLastModified getLastModified(FileLastModifiedParameterBuilder builder) throws SmartlingApiException;
 
     StringResponse getFile(GetFileParameterBuilder getFileParameterBuilder) throws SmartlingApiException;
+
+    StringResponse getFilesArchive(GetFilesArchiveParameterBuilder builder) throws SmartlingApiException;
 
     StringResponse getOriginalFile(GetOriginalFileParameterBuilder getFileParameterBuilder) throws SmartlingApiException;
 

--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/FileApiClientImpl.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/FileApiClientImpl.java
@@ -20,6 +20,7 @@ import com.smartling.api.sdk.file.parameters.FileListSearchParameterBuilder;
 import com.smartling.api.sdk.file.parameters.FileRenamePayload;
 import com.smartling.api.sdk.file.parameters.FileUploadParameterBuilder;
 import com.smartling.api.sdk.file.parameters.GetFileParameterBuilder;
+import com.smartling.api.sdk.file.parameters.GetFilesArchiveParameterBuilder;
 import com.smartling.api.sdk.file.parameters.GetOriginalFileParameterBuilder;
 import com.smartling.api.sdk.file.response.ApiV2ResponseWrapper;
 import com.smartling.api.sdk.file.response.EmptyResponse;
@@ -65,6 +66,7 @@ public final class FileApiClientImpl extends TokenProviderAwareClient implements
     private static final String FILES_API_V2_FILE_RENAME        = "/files-api/v2/projects/%s/file/rename";
     private static final String FILES_API_V2_FILE_LAST_MODIFIED = "/files-api/v2/projects/%s/file/last-modified";
     private static final String FILES_API_V2_GET_FILE           = "/files-api/v2/projects/%s/locales/%s/file";
+    private static final String FILES_API_V2_GET_FILES_ZIP      = "/files-api/v2/projects/%s/files/zip";
     private static final String FILES_API_V2_GET_ORIGINAL_FILE  = "/files-api/v2/projects/%s/file";
     private static final String FILES_API_V2_FILES_LIST         = "/files-api/v2/projects/%s/files/list";
     private static final String FILES_API_V2_FILE_LOCALE_STATUS = "/files-api/v2/projects/%s/locales/%s/file/status";
@@ -142,6 +144,33 @@ public final class FileApiClientImpl extends TokenProviderAwareClient implements
                 {
                 }
         ).retrieveData();
+    }
+
+    @Override
+    public StringResponse getFilesArchive(GetFilesArchiveParameterBuilder builder) throws SmartlingApiException
+    {
+        final List<NameValuePair> paramsList = builder.getNameValueList();
+        final String params = buildParamsQuery(paramsList.toArray(new NameValuePair[paramsList.size()]));
+
+        final HttpGet httpGet = new HttpGet(buildUrl(getApiUrl(FILES_API_V2_GET_FILES_ZIP), params));
+
+        final StringResponse response = executeRequest(httpGet);
+
+        if (response.isSuccess())
+        {
+            // This is a string representing the ZIP file contents
+            return response;
+        }
+        else
+        {
+            // Trying to get Smartling API exception from a json response
+            getApiV2Response(response.getContents(), new TypeToken<ApiV2ResponseWrapper<EmptyResponse>>()
+                    {
+                    }
+            ).retrieveData();
+            // Throw exception if no Exception has been thrown in previously
+            throw new SmartlingApiException("Failed to get file content");
+        }
     }
 
     @Override

--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/FileApiParameter.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/FileApiParameter.java
@@ -39,4 +39,8 @@ public class FileApiParameter
     public static final String OVERWRITE_AUTHORIZED_LOCALES = "overwriteAuthorizedLocales";
     public static final String INCLUDE_ORIGINAL_STRINGS     = "includeOriginalStrings";
     public static final String CLIENT_LIB_ID                = "smartling.client_lib_id";
+    public static final String LOCALE_IDS                   = "localeIds";
+    public static final String FILE_URIS                    = "fileUris";
+    public static final String FILE_NAME_MODE               = "fileNameMode";
+    public static final String LOCALE_MODE                  = "localeMode";
 }

--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/FileNameMode.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/FileNameMode.java
@@ -1,0 +1,8 @@
+package com.smartling.api.sdk.file.parameters;
+
+public enum FileNameMode
+{
+    UNCHANGED,
+    TRIM_LEADING,
+    LOCALE_LAST
+}

--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/GetFilesArchiveParameterBuilder.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/GetFilesArchiveParameterBuilder.java
@@ -1,0 +1,153 @@
+package com.smartling.api.sdk.file.parameters;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.smartling.api.sdk.file.parameters.FileApiParameter.FILE_NAME_MODE;
+import static com.smartling.api.sdk.file.parameters.FileApiParameter.FILE_URIS;
+import static com.smartling.api.sdk.file.parameters.FileApiParameter.INCLUDE_ORIGINAL_STRINGS;
+import static com.smartling.api.sdk.file.parameters.FileApiParameter.LOCALE_IDS;
+import static com.smartling.api.sdk.file.parameters.FileApiParameter.LOCALE_MODE;
+import static com.smartling.api.sdk.file.parameters.FileApiParameter.RETRIEVAL_TYPE;
+
+public class GetFilesArchiveParameterBuilder implements ParameterBuilder
+{
+    private List<String> fileUris;
+    private List<String> localeIds;
+    private Boolean includeOriginalStrings;
+    private RetrievalType retrievalType;
+    private FileNameMode fileNameMode;
+    private LocaleMode localeMode;
+
+    public GetFilesArchiveParameterBuilder()
+    {
+    }
+
+    public List<String> getFileUris()
+    {
+        return fileUris;
+    }
+
+    public List<String> getLocaleIds()
+    {
+        return localeIds;
+    }
+
+    public FileNameMode getFileNameMode()
+    {
+        return fileNameMode;
+    }
+
+    public LocaleMode getLocaleMode()
+    {
+        return localeMode;
+    }
+
+    public RetrievalType getRetrievalType()
+    {
+        return retrievalType;
+    }
+
+    public Boolean getIncludeOriginalStrings()
+    {
+        return includeOriginalStrings;
+    }
+
+    public GetFilesArchiveParameterBuilder files(List<String> fileUris)
+    {
+        this.fileUris = fileUris;
+        return this;
+    }
+
+    public GetFilesArchiveParameterBuilder localeIds(List<String> localeIds)
+    {
+        this.localeIds = localeIds;
+        return this;
+    }
+
+    /**
+     * retrievalType flag indicating the type of file retrieval being requested. Can be null.
+     * @param retrievalType retrieval type
+     * @return this builder
+     */
+    public GetFilesArchiveParameterBuilder retrievalType(RetrievalType retrievalType)
+    {
+        this.retrievalType = retrievalType;
+        return this;
+    }
+
+    /**
+     * include original strings
+     * @param includeOriginalStrings whether to include original string in file
+     * @return this builder
+     */
+    public GetFilesArchiveParameterBuilder includeOriginalStrings(Boolean includeOriginalStrings)
+    {
+        this.includeOriginalStrings = includeOriginalStrings;
+        return this;
+    }
+
+    public GetFilesArchiveParameterBuilder fileNameMode(FileNameMode fileNameMode)
+    {
+        this.fileNameMode = fileNameMode;
+        return this;
+    }
+
+    public GetFilesArchiveParameterBuilder localeMode(LocaleMode localeMode)
+    {
+        this.localeMode = localeMode;
+        return this;
+    }
+
+    @Override
+    public List<NameValuePair> getNameValueList()
+    {
+        final List<NameValuePair> paramsList = new LinkedList<NameValuePair>();
+
+        paramsList.addAll(convertFileUrisParams(FILE_URIS, fileUris));
+        paramsList.addAll(convertFileUrisParams(LOCALE_IDS, localeIds));
+
+        if (includeOriginalStrings != null)
+        {
+            paramsList.add(new BasicNameValuePair(INCLUDE_ORIGINAL_STRINGS, includeOriginalStrings.toString()));
+        }
+
+        if (retrievalType != null)
+        {
+            paramsList.add(new BasicNameValuePair(RETRIEVAL_TYPE, retrievalType.name()));
+        }
+
+        if (fileNameMode != null)
+        {
+            paramsList.add(new BasicNameValuePair(FILE_NAME_MODE, fileNameMode.name()));
+        }
+
+        if (localeMode != null)
+        {
+            paramsList.add(new BasicNameValuePair(LOCALE_MODE, localeMode.name()));
+        }
+
+        return paramsList;
+    }
+
+    private List<NameValuePair> convertFileUrisParams(final String prefix, final List<String> values)
+    {
+        if (values == null || values.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+
+        final List<NameValuePair> nameValuePairs = new ArrayList<>();
+        for (String value : values)
+        {
+            nameValuePairs.add(new BasicNameValuePair(prefix + "[]", value));
+        }
+
+        return nameValuePairs;
+    }
+}

--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/LocaleMode.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/parameters/LocaleMode.java
@@ -1,0 +1,8 @@
+package com.smartling.api.sdk.file.parameters;
+
+public enum LocaleMode
+{
+    LOCALE_IN_PATH,
+    LOCALE_IN_NAME,
+    LOCALE_IN_NAME_AND_PATH
+}

--- a/api-sdk/src/test/java/com/smartling/api/sdk/file/FileApiClientImplTest.java
+++ b/api-sdk/src/test/java/com/smartling/api/sdk/file/FileApiClientImplTest.java
@@ -12,6 +12,7 @@ import com.smartling.api.sdk.file.parameters.FileLastModifiedParameterBuilder;
 import com.smartling.api.sdk.file.parameters.FileListSearchParameterBuilder;
 import com.smartling.api.sdk.file.parameters.FileUploadParameterBuilder;
 import com.smartling.api.sdk.file.parameters.GetFileParameterBuilder;
+import com.smartling.api.sdk.file.parameters.GetFilesArchiveParameterBuilder;
 import com.smartling.api.sdk.file.parameters.GetOriginalFileParameterBuilder;
 import com.smartling.api.sdk.file.response.EmptyResponse;
 import com.smartling.api.sdk.file.response.FileImportSmartlingData;
@@ -39,6 +40,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static mockit.Deencapsulation.setField;
@@ -46,6 +48,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -220,6 +223,23 @@ public class FileApiClientImplTest
 
         HttpRequestBase request = requestCaptor.getValue();
         assertEquals("https://api.smartling.com/files-api/v2/projects/testProject/locales/" + LOCALE + "/file?fileUri=fileUri", request.getURI().toString());
+    }
+
+    @Test
+    public void testGetFilesArchive() throws Exception
+    {
+        when(response.getContentsRaw()).thenReturn("contents of a zip file".getBytes());
+
+        StringResponse r = fileApiClient.getFilesArchive(new GetFilesArchiveParameterBuilder()
+                .files(Arrays.asList("fileUri1", "fileUri2"))
+                .localeIds(Arrays.asList("locale1", "locale2"))
+        );
+
+        HttpRequestBase request = requestCaptor.getValue();
+        assertEquals("https://api.smartling.com/files-api/v2/projects/testProject/files/zip" +
+                "?fileUris%5B%5D=fileUri1&fileUris%5B%5D=fileUri2&localeIds%5B%5D=locale1&localeIds%5B%5D=locale2",
+                request.getURI().toString());
+        assertArrayEquals("contents of a zip file".getBytes(), r.getContentsRaw());
     }
 
     @Test


### PR DESCRIPTION
Documentation: https://help.smartling.com/v1.0/reference#get_projects-projectid-files-zip

The `FileApiClient.getFiles()` method will return a [StringResponse](https://github.com/Smartling/api-sdk-java/blob/70389f8/api-sdk/src/main/java/com/smartling/api/sdk/dto/file/StringResponse.java), containing the entire zip file. That file can then be written to a File or processed in memory using `java.util.zip.ZipInputStream`.