### PR TITLE
Bump commons-collections library version

### DIFF
--- a/api-sdk/pom.xml
+++ b/api-sdk/pom.xml
@@ -257,7 +257,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.smartling</groupId>


### PR DESCRIPTION
`commons-collection` is a potential subject to a vulnerability https://nvd.nist.gov/vuln/detail/CVE-2017-15708
This change will update the library version