### PR TITLE
Update FileType.java

### DIFF
--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/FileType.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/FileType.java
@@ -44,6 +44,7 @@ public enum FileType
     STRINGSDICT("application/xml", true),           // iOS/OSX resources in dictionary format
     MADCAP("application/octet-stream", false),      // MADCAP file
     SRT("text/plain", false);                       // SubRip Text Format
+    MARKDOWN("text/markdown", true);                // Markdown text format
 
     private final String identifier;
     private final String mimeType;


### PR DESCRIPTION
Add the markdown enum value to file type supported by Smartling to enable the use of sdk to update .md or .markdown file to Smartling site