### PR TITLE
Repo 239 new FileType lookup() and missed file types

### DIFF
--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/FileType.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/FileType.java
@@ -47,7 +47,11 @@ public enum FileType
     STRINGSDICT("application/xml", true),           // iOS/OSX resources in dictionary format
     MADCAP("application/octet-stream", false),      // MADCAP file
     SRT("text/plain", false),                       // SubRip Text Format
-    MARKDOWN("text/markdown", true);                // Markdown Text Format
+    MARKDOWN("text/markdown", true),                // Markdown Text Format
+    PHP_RESOURCE("text/plain", false),              // PHP resources
+    TMX("application/xml", false),                  // TMX translation memory file format
+    XLIFF_CAT("application/xml", false),            // XLIFF for offline CAT integration
+    DITA("application/xml", false);                 // DITA file format
 
     private final String identifier;
     private final String mimeType;

--- a/api-sdk/src/main/java/com/smartling/api/sdk/file/FileType.java
+++ b/api-sdk/src/main/java/com/smartling/api/sdk/file/FileType.java
@@ -17,6 +17,9 @@ package com.smartling.api.sdk.file;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum FileType
 {
     JAVA_PROPERTIES("text/plain", true),            // Java resources
@@ -50,7 +53,19 @@ public enum FileType
     private final String mimeType;
     private final boolean isTextFormat;
 
-    private static String createIdentifier(String s)
+    // Lookup map
+    public final static Map<String, FileType> BY_NAME_LOOKUP = new HashMap<>();
+
+    static
+    {
+        for (final FileType value : FileType.values())
+        {
+            BY_NAME_LOOKUP.put(value.identifier.toLowerCase(), value);
+            BY_NAME_LOOKUP.put(value.name().toLowerCase(), value);
+        }
+    }
+
+    private static String toLowerCamel(String s)
     {
         StringBuilder buf = new StringBuilder();
         String[] parts = s.split("_");
@@ -61,9 +76,9 @@ public enum FileType
         return buf.toString();
     }
 
-    private FileType(final String mimeType, final boolean isTextFormat)
+    FileType(final String mimeType, final boolean isTextFormat)
     {
-        this.identifier = createIdentifier(name());
+        this.identifier = toLowerCamel(name());
         this.mimeType = mimeType;
         this.isTextFormat = isTextFormat;
     }
@@ -85,12 +100,6 @@ public enum FileType
 
     public static FileType lookup(final String fileTypeString)
     {
-        for (final FileType fileType : FileType.values())
-        {
-            if (fileType.identifier.equalsIgnoreCase(fileTypeString))
-                return fileType;
-        }
-
-        return null;
+        return BY_NAME_LOOKUP.get(StringUtils.lowerCase(fileTypeString));
     }
 }

--- a/api-sdk/src/test/java/com/smartling/api/sdk/file/FileTypeTest.java
+++ b/api-sdk/src/test/java/com/smartling/api/sdk/file/FileTypeTest.java
@@ -1,0 +1,20 @@
+package com.smartling.api.sdk.file;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.smartling.api.sdk.file.FileType.JAVA_PROPERTIES;
+
+public class FileTypeTest
+{
+    @Test
+    public void testLookup()
+    {
+        Assert.assertEquals(JAVA_PROPERTIES, FileType.lookup("javaProperties"));
+        Assert.assertEquals(JAVA_PROPERTIES, FileType.lookup("JaVaPrOpErTiEs"));
+        Assert.assertEquals(JAVA_PROPERTIES, FileType.lookup("JaVa_PrOpErTiEs"));
+        Assert.assertEquals(JAVA_PROPERTIES, FileType.lookup(JAVA_PROPERTIES.name()));
+        Assert.assertEquals(JAVA_PROPERTIES, FileType.lookup(JAVA_PROPERTIES.toString()));
+        Assert.assertNull(FileType.lookup("A_NON_EXISTING_CONTENT_TYPE"));
+    }
+}


### PR DESCRIPTION
Changed `FileType.lookup()` logic to fit with the type strings that `FileApi` accept
I looked [here](https://github.com/Smartling/tms/blob/master/model/interface/src/main/java/com/smartling/model/contentfiles/ContentFileType.java) for the reference

`FileType.lookup()` stays backward compatible, but now it should also accept snake-cased type names

Also added 4 file types which weren't present in the list - please check their mime types